### PR TITLE
Conversion issues:

### DIFF
--- a/Roslyn/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/Roslyn/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -703,7 +703,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (integralTypes && Compilation.Options.Dialect != XSharpDialect.Core)
             {
-                return XsHandleIntegralTypes(result,leftType, rightType);
+                return XsHandleIntegralTypes(node, result, leftType, rightType);
             }
             return result;
 #endif

--- a/Tests/Applications/C519/Prg/C519.prg
+++ b/Tests/Applications/C519/Prg/C519.prg
@@ -7,7 +7,8 @@ p := 1 //ok
 p := 2 //ok
 p := iif(l , 3 , 4) // error XS0266
 ? p
-xAssert(p == 3)
+xAssert(p == 3)    
+
 
 
 // code from bBrowser:

--- a/Tests/Applications/C834/Prg/C834.prg
+++ b/Tests/Applications/C834/Prg/C834.prg
@@ -1,6 +1,7 @@
 // 834. Compiler error with the += and -= operators between INT/FLOAT
 // /vo11+  
 #pragma options("vo11", on)     // conversions between different sizes and from fractional to integral
+#pragma options("vo4", on)     // conversions between different sizes and from fractional to integral
 
 FUNCTION Start( ) AS VOID
 	LOCAL n := 1 AS INT
@@ -8,7 +9,7 @@ FUNCTION Start( ) AS VOID
 	LOCAL f := 3.0 AS FLOAT
 	LOCAL r := 3.0 AS REAL8
 	
-	n := f
+	n := f   
 	n := n + f // OK
 	n += f     // error XS0266: Cannot implicitly convert type 'FLOAT' to 'int'. An explicit conversion exists (are you missing a cast?)
 	xAssert(n == 9)
@@ -36,7 +37,23 @@ FUNCTION Start( ) AS VOID
 	d -= r
 	xAssert(d == 6)
 
+    d := d + 1
+    d += 1
+    d -= 1
+    d /= 1
+    d *= 1
+
+    d >>= 1       
+    n := d             
+    n := n + d
+    n += d
+    n -= d
+    n *= d
+    n >>= d
+    
+    
 RETURN
+             
 
 PROC xAssert(l AS LOGIC) 
 IF .NOT. l

--- a/Tests/Applications/R836/Prg/R836.prg
+++ b/Tests/Applications/R836/Prg/R836.prg
@@ -1,4 +1,5 @@
 // https://github.com/X-Sharp/XSharpPublic/issues/951
+
 FUNCTION Start( ) AS VOID
     LOCAL f := -1343.345 AS FLOAT  // "AS DOUBLE" throws an compile error
     LOCAL c := -1343.345 AS CURRENCY  // "AS DOUBLE" throws an compile error

--- a/Tests/Applications/R841/Prg/R841.prg
+++ b/Tests/Applications/R841/Prg/R841.prg
@@ -1,0 +1,23 @@
+#pragma options("vo4", on)
+DEFINE FAPPCOMMAND_MASK := 0xF000
+FUNCTION Start( ) AS VOID
+	System.Console.WriteLine("Hello x#!")
+RETURN
+
+
+FUNCTION Get_AppCommand_lParam(lParam AS DWORD) AS DWORD
+	RETURN _AND(HiWord(lParam),_NOT(FAPPCOMMAND_MASK))
+
+
+
+FUNCTION SwapBytes(nShort AS SHORT) AS Short
+    RETURN _OR( _AND(nShort, 0xFF) <<8, _AND(nShort >>8, 0xFF))
+DEFINE UUE_START_NEWS            := "begin"    
+    
+function TestMe as string                                         
+    local cTemp as string
+    local nRet as dword                    
+    local c := "aaabeginbbb" as string
+    nRet := 1
+    cTemp   := SubStr(c, nRet + SLen(UUE_START_NEWS), 5)    
+    return cTemp

--- a/Tests/xSharp Tests.viproj
+++ b/Tests/xSharp Tests.viproj
@@ -104637,7 +104637,7 @@ VO7=1
 VO8=0
 VO9=0
 VO10=0
-VO11=0
+VO11=1
 VO12=0
 VO13=0
 VO14=0
@@ -104666,7 +104666,7 @@ AppConfig = Debug,11111111-1111-1111-1111-111111111111
   DefineDebug=1
   DefineTrace=0
   SyntaxOnly=0
-  WarningsErrors=1
+  WarningsErrors=0
   ForceConsole=0
   ForceX86=0
   Optimize=0
@@ -106037,6 +106037,119 @@ AppConfig = Release,22222222-2222-2222-2222-222222222222
   ForceX86=0
   Optimize=0
 ENDApplication = C838 - Missing compiler errors on incorrect usa of OVERRIDE on ACCESSes
+
+ApplicationGroup = 084FC9A2-9274-4770-AE44-6D078B06BA37
+; ************** APPLICATION R841 - Warnings that should not be thrown *************
+Application = R841 - Warnings that should not be thrown
+IDEVersion = 1.06
+GalleryName = 
+GalleryPage = 
+GalleryDefaultName = 
+Target = 0
+Platform = AnyCPU
+Language = XSharp
+Runtime = CLR4
+Dialect = VO
+Folder = %ProjectPath%\Applications\R841\
+PrgSubFolder = \Prg
+ResourcesSubFolder = \Resources
+Description = Just a simple x# application
+NameSpace = 
+Assembly = R841
+Extension = 
+ApplicationIcon = 
+OutputFolder = 
+Frameworks = 1
+GUID = 6C142E23-1E68-4811-9206-C96420130ACA
+IncludeInProjectBuild = 1
+IncludeInProjectSearch = 1
+IncludeInProjectExport = 1
+IncludePath = 
+StdDefsFile = 
+AppToRun = 
+SignAssembly = 0
+KeyFile = 
+
+[ExportOptions]
+ExportResources = 0
+ExportImages = 0
+[R841 - Warnings that should not be thrown FileGroups]
+[R841 - Warnings that should not be thrown Files]
+File = %AppPath%\Prg\R841.prg
+FileGUID = 89CEA7FF-1A74-4924-90E1-EF9859D7D166
+FileType = Code
+CopyToBin = 0
+[R841 - Warnings that should not be thrown References]
+ReferenceGAC = CLR4,System,1,0,4.0.0.0
+ReferenceGAC = CLR4,System.Core,1,0,4.0.0.0
+ReferenceBrowse = C:\XSharp\DevRt\Binaries\Debug\XSharp.Core.dll,1,0
+ReferenceBrowse = C:\XSharp\DevRt\Binaries\Debug\XSharp.RT.dll,1,0
+[R841 - Warnings that should not be thrown Resources]
+[R841 - Warnings that should not be thrown Native Resources]
+[R841 - Warnings that should not be thrown License files]
+[R841 - Warnings that should not be thrown General Options]
+Switches=
+ZeroArrays=0
+CaseSensitive=0
+ImplicitNamespace=0
+VO1=0
+VO2=0
+VO3=0
+VO4=0
+VO5=0
+VO6=0
+VO7=0
+VO8=0
+VO9=0
+VO10=0
+VO11=0
+VO12=0
+VO13=0
+VO14=0
+VO16=0
+FOX1=0
+FOX2=0
+XPP1=0
+LateBound=0
+Unsafe=0
+Undeclared=0
+EnforceSelf=0
+UseNativeVersion=0
+MemVar=0
+IgnoreStdDefs=0
+Ovf=0
+FOvf=0
+ResponseOnly=0
+[R841 - Warnings that should not be thrown Configurations]
+AppConfig = Debug,11111111-1111-1111-1111-111111111111
+  Switches=
+  SwitchesCF=
+  CommandLine=
+  CommandLineCF=
+  Debug=1
+  DebugInit=1
+  DefineDebug=1
+  DefineTrace=0
+  SyntaxOnly=0
+  WarningsErrors=0
+  ForceConsole=0
+  ForceX86=0
+  Optimize=0
+AppConfig = Release,22222222-2222-2222-2222-222222222222
+  Switches=
+  SwitchesCF=
+  CommandLine=
+  CommandLineCF=
+  Debug=0
+  DebugInit=0
+  DefineDebug=0
+  DefineTrace=0
+  SyntaxOnly=0
+  WarningsErrors=1
+  ForceConsole=0
+  ForceX86=0
+  Optimize=0
+ENDApplication = R841 - Warnings that should not be thrown
 [EndApplications]
 
 [Configurations]

--- a/XSharp/src/Common/BuildNumber.h
+++ b/XSharp/src/Common/BuildNumber.h
@@ -13,13 +13,13 @@
 #ifdef RUNTIME
     #define VERSION_NUMBER     "2.6.0.0"
 #else
-    #define VERSION_NUMBER     "2.11.0.0"
+    #define VERSION_NUMBER     "2.11.0.1"
 #endif
 
     // This is the file version number, which is ignored by .NET but used by Windows installer to determine
     // whether one file is newer than another.
     // This typically would change if we're generating a patch, otherwise it should be the same as VERSION_NUMBER
-    #define FILEVERSION_NUMBER   "2.11.0.0"
+    #define FILEVERSION_NUMBER   "2.11.0.1"
     #define INFORMATIONAL_NUMBER  "2.11 GA"
 
     #ifdef __DEBUG__

--- a/XSharp/src/Common/Constants.cs
+++ b/XSharp/src/Common/Constants.cs
@@ -16,9 +16,9 @@ namespace XSharp
 #if RUNTIME
         internal const string Version = "2.6.0.0";
 #else
-        internal const string Version = "2.11.0.0";
+        internal const string Version = "2.11.0.1";
 #endif
-        internal const string FileVersion = "2.11.0.0";
+        internal const string FileVersion = "2.11.0.1";
         internal const string ProductVersion = "2.11 GA";
         internal const string PublicKey = "ed555a0467764586";
         internal const string Copyright = "Copyright © XSharp BV 2015-2022";

--- a/XSharp/src/Compiler/XSharpCodeAnalysis/Binder/Binder_Operators.cs
+++ b/XSharp/src/Compiler/XSharpCodeAnalysis/Binder/Binder_Operators.cs
@@ -1213,11 +1213,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             return constant;
         }
 
-        BoundExpression XsHandleIntegralTypes(BoundBinaryOperator binaryOperator, TypeSymbol leftType, TypeSymbol rightType)
+        BoundExpression XsHandleIntegralTypes(BinaryExpressionSyntax node, BoundBinaryOperator binaryOperator, TypeSymbol leftType, TypeSymbol rightType)
         {
             // This is the place where we will handle VO specific conversion
             // when the left and right types are equal we want a result of the same type.
             // also shift operations should return the left type: C277 ByteValue >> 2 should not return int but byte.
+
+            if (!Equals(binaryOperator.Right.Type, rightType) || !Equals(binaryOperator.Left.Type, leftType))
+            {
+                node.XWarning = true;
+            }
+
             BoundExpression result = binaryOperator;
             var kind = binaryOperator.OperatorKind;
             if (kind.IsComparison())
@@ -1257,8 +1263,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     { WasCompilerGenerated = true };
                 }
             }
-                return result;
-            }
+            return result;
+        }
         bool XsConstantFitsInType(BoundExpression result, TypeSymbol preferredType)
         {
             bool fits = true;

--- a/XSharp/src/Compiler/XSharpCodeAnalysis/Binder/Semantics/Conversions.cs
+++ b/XSharp/src/Compiler/XSharpCodeAnalysis/Binder/Semantics/Conversions.cs
@@ -233,12 +233,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // when both same # of bits and integral, use Identity conversion
                         if (srcType.SizeInBytes() == dstType.SizeInBytes())
                         {
-                            var constant = false;
-                            if (sourceExpression is BoundBinaryOperator bop)
-                            {
-                                constant = bop.Left.ConstantValue != null || bop.Right.ConstantValue != null;
-                            }
-                            syntax.XWarning = !constant && !syntax.XGenerated;
+                            syntax.XWarning = !syntax.XGenerated;
                             result = Conversion.Identity;
                         }
                         else if (vo11)
@@ -248,14 +243,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                             result = Conversion.ImplicitNumeric;
                         }
                     }
-                    else if (vo11 && dstType.IsIntegralType() && sourceExpression.ConstantValue == null)
+                    else if (vo11 && dstType.IsIntegralType())
                     {
                         syntax.XWarning = !syntax.XGenerated;
                         result = Conversion.ImplicitNumeric;
                     }
                 }
                 // VO/Vulcan also allows to convert floating point types <-> integral types
-                if (result == Conversion.NoConversion && (source.IsFloatType() || source.IsCurrencyType()))
+                if (result == Conversion.NoConversion && vo11 && (source.IsFloatType() || source.IsCurrencyType()))
                 {
                     if (destination is { } && destination.SpecialType.IsNumericType())
                     {

--- a/XSharp/src/Compiler/XSharpCodeAnalysis/Binder/TypeExtensions.cs
+++ b/XSharp/src/Compiler/XSharpCodeAnalysis/Binder/TypeExtensions.cs
@@ -14,6 +14,31 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal static class TypeExtensions
     {
+        /// <summary>
+        /// Walk a an expression tree to detect if a constant element is involved.
+        /// NOTE: this may not be complete !
+        /// </summary>
+        /// <param name="expr"></param>
+        /// <returns></returns>
+        internal static bool HasConstant(this BoundExpression expr)
+        {
+            if (expr.ConstantValue != null)
+                return true;
+            switch (expr)
+            {
+                case BoundUnaryOperator unop:
+                    return unop.Operand.HasConstant();
+                case BoundBinaryOperatorBase binop:
+                    return binop.Left.HasConstant() || binop.Right.HasConstant();
+                case BoundConversion conv:
+                    return conv.Operand.HasConstant();
+                case BoundCompoundAssignmentOperator bao:
+                    return bao.Left.HasConstant() || bao.Right.HasConstant();
+
+            }
+            return false;
+
+        }
 
         internal static bool IsXsCompilerGenerated(this Symbol symbol) 
         {


### PR DESCRIPTION
- Checks for constants are no longer done in the Conversion checking code but in the diagnostics pass
- Automatic Float -> Number conversions are done only when /vo11 is enabled
- Added code to walk an expression tree for constants
- Added code to walk a syntax tree for the XGenerated flags